### PR TITLE
Fix typo

### DIFF
--- a/rst/ch08/09.rst
+++ b/rst/ch08/09.rst
@@ -10,7 +10,7 @@
    In [6]: d
    Out[6]: {1: 'python'}
 
-   ### key=1,value=java的键值对神器消失了
+   ### key=1,value=java的键值对神奇地消失了
    In [7]: d[1]
    Out[7]: 'python'
    In [8]: d[1.0]


### PR DESCRIPTION
将错别字"神器"改为"神奇地"